### PR TITLE
Add rollData to text descriptions

### DIFF
--- a/scripts/visual-active-effects.mjs
+++ b/scripts/visual-active-effects.mjs
@@ -36,17 +36,18 @@ export class VisualActiveEffects extends Application {
       // Set up the various text (intro and content).
       const desc = entry.effect.flags["dfreds-convenient-effects"]?.description;
       const data = entry.effect.flags[MODULE]?.data ?? {};
+      const rollData = (await fromUuid(entry.effect.origin))?.getRollData() || {};
 
       // Set up intro if it exists.
       const intro = entry.effect.description || desc;
-      if (intro) entry.context.strings.intro = await TextEditor.enrichHTML(intro);
+      if (intro) entry.context.strings.intro = await TextEditor.enrichHTML(intro, {rollData});
 
       // Set up content if it exists.
       if (data.content?.length) {
         // The 'header' for the collapsible's header with default 'Details'.
         entry.context.strings.header = data.header || game.i18n.localize("VISUAL_ACTIVE_EFFECTS.LABELS.DETAILS");
         // The collapsible content.
-        entry.context.strings.content = await TextEditor.enrichHTML(data.content);
+        entry.context.strings.content = await TextEditor.enrichHTML(data.content, {rollData});
       }
 
       // Add to either disabled array, enabled array, or passive array.

--- a/scripts/visual-active-effects.mjs
+++ b/scripts/visual-active-effects.mjs
@@ -38,10 +38,10 @@ export class VisualActiveEffects extends Application {
       const data = entry.effect.flags[MODULE]?.data ?? {};
       
       // Get the effect rollData to populate enrichers within the descriptions.
-      let rollData = {};
+      let rollData;
       try {
         if (entry.effect.origin) {
-          let origin = await fromUuid(entry.effect.origin);
+          let origin = fromUuidSync(entry.effect.origin);
           if (origin?.documentName === ActiveEffect.documentName) {
             // Change the origin to the parent of the ActiveEffect - the originating item or actor.
             origin = origin.parent;
@@ -56,11 +56,7 @@ export class VisualActiveEffects extends Application {
         }
 
         // Fallback to the parent if there's no rollData.
-        if (!rollData || !Object.keys(rollData).length) {
-          if (typeof entry.effect.parent?.getRollData === "function") {
-            rollData = entry.effect.parent.getRollData();
-          }
-        }
+        if (!rollData) rollData = entry.effect.parent.getRollData();
       } catch (_) {
         // Fallback to just an empty object - enrichers will show empty values in this case.
         rollData = {};

--- a/scripts/visual-active-effects.mjs
+++ b/scripts/visual-active-effects.mjs
@@ -36,7 +36,21 @@ export class VisualActiveEffects extends Application {
       // Set up the various text (intro and content).
       const desc = entry.effect.flags["dfreds-convenient-effects"]?.description;
       const data = entry.effect.flags[MODULE]?.data ?? {};
-      const rollData = (await fromUuid(entry.effect.origin))?.getRollData() || {};
+      
+      // Get the effect rollData to populate enrichers within the descriptions.
+      let rollData = {};
+      if (entry.effect.origin) {
+        const origin = await fromUuid(entry.effect.origin);
+        if (origin && typeof origin.getRollData === 'function') {
+          rollData = origin.getRollData();
+        }
+      }
+      // Fallback to the parent if there's no rollData.
+      if (!Object.keys(rollData).length) {
+        if (typeof entry.effect.parent?.getRollData === 'function') {
+          rollData = entry.parent.getRollData();
+        }
+      }
 
       // Set up intro if it exists.
       const intro = entry.effect.description || desc;


### PR DESCRIPTION
Provide the rollData from the origin item to allow enrichers to function correctly.

Using this description (as an example): `While you are conscious, you grant all friendly creatures (including you) within [[@scale.paladin.aura-radius]] ft. a +[[@abilities.cha.mod]] bonus to all saving throws.`

The enriched details would always resolve to 0.

![image](https://github.com/krbz999/visual-active-effects/assets/293277/67f741e2-254b-4d57-a330-2b5de7e55dd7)

After this patch:

![image](https://github.com/krbz999/visual-active-effects/assets/293277/7b8627aa-f727-4296-96a6-b942281a988e)
