### PR TITLE
[#54] Apply icon tint

### DIFF
--- a/styles/visual-active-effects.css
+++ b/styles/visual-active-effects.css
@@ -125,6 +125,14 @@
         filter: brightness(0.25) grayscale(1);
       }
 
+      .effect-icon-img {
+        height: inherit;
+        width: inherit;
+        background-size: inherit;
+        background-blend-mode: multiply;
+        mask-size: contain; 
+      }
+
       .badge {
         bottom: 5%;
         color: white;

--- a/templates/effect.hbs
+++ b/templates/effect.hbs
@@ -45,7 +45,8 @@
 
   </div>
 
-  <div class="effect-icon {{#if effect.disabled}}inactive{{/if}}" style="background-image: url({{effect.img}})" data-action="deleteEffect">
+  <div class="effect-icon {{#if effect.disabled}}inactive{{/if}}" data-action="deleteEffect">
+    <div class="effect-icon-img" style="background-image: url({{effect.img}}); mask-image: url({{effect.img}}); {{#unless effect.disabled}}background-color: {{effect.tint.css}};{{/unless}}"></div>
     {{#if effect.isTemporary}}
     {{#if isExpired}}
     <i class="expired badge fa-solid fa-clock"></i>


### PR DESCRIPTION
Would close #54.

Initially, just added the `background-color` and `background-blend-mode`. That caused problems with partially transparent icons, as it would give the background the full, 100% opacity tint color, instead of leaving it transparent. So, added the `mask-image` and `mask-size`. That, however, killed the clock/infinity unless it was on top of the opaque part of the icon, so I split the actual background-image-containing element into its own `div` and gave it its own style class.

Not sure if there's a cleaner thing to do than just another div, but this seems fine to me. Tested on Chrome, Edge, and Firefox, just in case.